### PR TITLE
Implement sequences drop for clean function

### DIFF
--- a/oapth/src/fixed_sql_commands/pg.rs
+++ b/oapth/src/fixed_sql_commands/pg.rs
@@ -3,11 +3,11 @@ use core::fmt::Write;
 
 pub const CREATE_MIGRATION_TABLES: &str = concat!(
   "CREATE SCHEMA IF NOT EXISTS _oapth; \
-  
+
   CREATE TABLE IF NOT EXISTS _oapth._oapth_migration_group (",
   oapth_migration_group_columns!(),
   ");
-  
+
   CREATE TABLE IF NOT EXISTS _oapth._oapth_migration (",
   serial_id!(),
   "created_on TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,",
@@ -26,29 +26,49 @@ where
   for schema in schemas(back_end).await? {
     buffer.write_fmt(format_args!("DROP SCHEMA {} CASCADE;", schema))?;
   }
-  
+
   for domain in domains(back_end, "public").await? {
     buffer.write_fmt(format_args!("DROP DOMAIN {};", domain))?;
   }
-  
+
   for function in functions(back_end, "public").await? {
     buffer.write_fmt(format_args!("DROP FUNCTION {} CASCADE;", function))?;
   }
-  
+
   for table in back_end.tables("public").await? {
     buffer.write_fmt(format_args!("DROP TABLE {} CASCADE;", table))?;
   }
-  
+
   for procedure in procedures(back_end, "public").await? {
     buffer.write_fmt(format_args!("DROP PROCEDURE {} CASCADE;", procedure))?;
   }
-  
+
   for ty in types(back_end, "public").await? {
     buffer.write_fmt(format_args!("DROP TYPE {} CASCADE;", ty))?;
   }
 
+  for sequence in sequences(back_end, "public").await? {
+      buffer.write_fmt(format_args!("DROP SEQUENCE {};", sequence))?;
+  }
+
   Ok(buffer)
 }
+
+// https://github.com/flyway/flyway/blob/master/flyway-core/src/main/java/org/flywaydb/core/internal/database/postgresql/PostgreSQLSchema.java
+#[oapth_macros::dev_tools_]
+#[inline]
+pub async fn sequences<B>(back_end: &mut B, schema: & str) -> crate::Result<Vec<String>>
+where
+ B: crate::BackEnd
+{
+    let mut buffer = ArrayString::<[u8; 128]>::new();
+    buffer.write_fmt(format_args!(
+            "SELECT sequence_name FROM information_schema.sequences WHERE sequence_schema = '{schema}'",
+            schema = schema
+            ))?;
+    Ok(back_end.query_string(&buffer).await?)
+}
+
 
 // https://github.com/flyway/flyway/blob/master/flyway-core/src/main/java/org/flywaydb/core/internal/database/postgresql/PostgreSQLSchema.java
 #[oapth_macros::dev_tools_]
@@ -59,7 +79,7 @@ where
 {
   let mut buffer = ArrayString::<[u8; 512]>::new();
   buffer.write_fmt(format_args!(
-    "      
+    "
     SELECT
       t.typname AS generic_column
     FROM pg_catalog.pg_type t
@@ -154,11 +174,11 @@ where
       typname AS generic_column
     FROM
       pg_catalog.pg_type t
-      LEFT JOIN pg_depend dep ON dep.objid = t.oid and dep.deptype = 'e' 
+      LEFT JOIN pg_depend dep ON dep.objid = t.oid and dep.deptype = 'e'
     WHERE
       (t.typrelid = 0 OR (
         SELECT c.relkind = 'c' FROM pg_catalog.pg_class c WHERE c.oid = t.typrelid)
-      ) 
+      )
       AND NOT EXISTS(
         SELECT 1 FROM pg_catalog.pg_type el WHERE el.oid = t.typelem AND el.typarray = t.oid
       )
@@ -179,7 +199,7 @@ fn pg_proc(prokind: char, schema: &str) -> crate::Result<ArrayString<[u8; 512]>>
 {
   let mut buffer = ArrayString::new();
   buffer.write_fmt(format_args!(
-    "      
+    "
     SELECT
       proname AS generic_column
     FROM

--- a/oapth/src/fixed_sql_commands/pg.rs
+++ b/oapth/src/fixed_sql_commands/pg.rs
@@ -63,7 +63,7 @@ where
 {
     let mut buffer = ArrayString::<[u8; 128]>::new();
     buffer.write_fmt(format_args!(
-            "SELECT sequence_name FROM information_schema.sequences WHERE sequence_schema = '{schema}'",
+            "SELECT sequence_name  AS generic_column FROM information_schema.sequences WHERE sequence_schema = '{schema}'",
             schema = schema
             ))?;
     Ok(back_end.query_string(&buffer).await?)

--- a/oapth/src/integration_tests/db/pg.rs
+++ b/oapth/src/integration_tests/db/pg.rs
@@ -14,6 +14,7 @@ pub async fn clean_drops_all_objs<B>(
   c.back_end.execute("CREATE FUNCTION time_subtype_diff(x time, y time) RETURNS float8 AS 'SELECT EXTRACT(EPOCH FROM (x - y))' LANGUAGE sql STRICT IMMUTABLE").await.unwrap();
   c.back_end.execute("CREATE PROCEDURE something() LANGUAGE SQL AS $$ $$").await.unwrap();
   c.back_end.execute("CREATE TYPE A_TYPE AS (field INTEGER[31])").await.unwrap();
+  c.back_end.execute("CREATE SEQUENCE serial START 101;").await.unwrap();
 
   assert_eq!(crate::fixed_sql_commands::pg::schemas(&mut c.back_end).await.unwrap().len(), 1);
   assert_eq!(c.back_end.tables(aux.default_schema).await.unwrap().len(), 1);
@@ -21,6 +22,7 @@ pub async fn clean_drops_all_objs<B>(
   assert_eq!(crate::fixed_sql_commands::pg::functions(&mut c.back_end, "public").await.unwrap().len(), 1);
   assert_eq!(crate::fixed_sql_commands::pg::procedures(&mut c.back_end, "public").await.unwrap().len(), 1);
   assert_eq!(crate::fixed_sql_commands::pg::types(&mut c.back_end, "public").await.unwrap().len(), 1);
+  assert_eq!(crate::fixed_sql_commands::pg::sequences(&mut c.back_end, "public").await.unwrap().len(), 1);
 
   c.clean().await.unwrap();
 
@@ -30,4 +32,5 @@ pub async fn clean_drops_all_objs<B>(
   assert_eq!(crate::fixed_sql_commands::pg::functions(&mut c.back_end, "public").await.unwrap().len(), 0);
   assert_eq!(crate::fixed_sql_commands::pg::procedures(&mut c.back_end, "public").await.unwrap().len(), 0);
   assert_eq!(crate::fixed_sql_commands::pg::types(&mut c.back_end, "public").await.unwrap().len(), 0);
+  assert_eq!(crate::fixed_sql_commands::pg::sequences(&mut c.back_end, "public").await.unwrap().len(), 0);
 }


### PR DESCRIPTION
Fixes #6

Changes Proposed 

- [x]  Build dropping of sequences into clean for postgres


@c410-f3r  so I have this implemented however my tests fail with an error I cant yet debug please see below 

```
failures:

---- integration_tests::integration_tests stdout ----
thread 'integration_tests::integration_tests' panicked at 'called `Result::unwrap()` on an `Err` value: Diesel connection: FATAL:  role "oapth" does not exist
', oapth/src/integration_tests.rs:237:1
stack backtrace:
   0: rust_begin_unwind
             at /rustc/b1496c6e606dd908dd651ac2cce89815e10d7fc5/library/std/src/panicking.rs:483:5
   1: core::panicking::panic_fmt
             at /rustc/b1496c6e606dd908dd651ac2cce89815e10d7fc5/library/core/src/panicking.rs:85:14
   2: core::option::expect_none_failed
             at /rustc/b1496c6e606dd908dd651ac2cce89815e10d7fc5/library/core/src/option.rs:1238:5
   3: core::result::Result<T,E>::unwrap
             at /rustc/b1496c6e606dd908dd651ac2cce89815e10d7fc5/library/core/src/result.rs:973:23
   4: oapth::integration_tests::integration_tests_back_end::{{closure}}
             at ./src/integration_tests.rs:55:11
   5: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/b1496c6e606dd908dd651ac2cce89815e10d7fc5/library/core/src/future/mod.rs:80:19
   6: oapth::integration_tests::integration_tests::{{closure}}
             at ./src/integration_tests.rs:237:1
   7: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /rustc/b1496c6e606dd908dd651ac2cce89815e10d7fc5/library/core/src/future/mod.rs:80:19
   8: tokio::runtime::basic_scheduler::BasicScheduler<P>::block_on::{{closure}}::{{closure}}
             at /Users/zacck/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/basic_scheduler.rs:131:58
   9: tokio::coop::with_budget::{{closure}}
             at /Users/zacck/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/coop.rs:127:9
  10: std::thread::local::LocalKey<T>::try_with
             at /rustc/b1496c6e606dd908dd651ac2cce89815e10d7fc5/library/std/src/thread/local.rs:272:16
  11: std::thread::local::LocalKey<T>::with
             at /rustc/b1496c6e606dd908dd651ac2cce89815e10d7fc5/library/std/src/thread/local.rs:248:9
  12: tokio::coop::with_budget
             at /Users/zacck/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/coop.rs:120:5
  13: tokio::coop::budget
             at /Users/zacck/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/coop.rs:96:5
  14: tokio::runtime::basic_scheduler::BasicScheduler<P>::block_on::{{closure}}
             at /Users/zacck/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/basic_scheduler.rs:131:35
  15: tokio::runtime::basic_scheduler::enter::{{closure}}
             at /Users/zacck/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/basic_scheduler.rs:213:29
  16: tokio::macros::scoped_tls::ScopedKey<T>::set
             at /Users/zacck/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/macros/scoped_tls.rs:63:9
  17: tokio::runtime::basic_scheduler::enter
             at /Users/zacck/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/basic_scheduler.rs:213:5
  18: tokio::runtime::basic_scheduler::BasicScheduler<P>::block_on
             at /Users/zacck/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/basic_scheduler.rs:123:9
  19: tokio::runtime::Runtime::block_on::{{closure}}
             at /Users/zacck/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/mod.rs:444:34
  20: tokio::runtime::context::enter
             at /Users/zacck/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/context.rs:72:5
  21: tokio::runtime::handle::Handle::enter
             at /Users/zacck/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/handle.rs:76:9
  22: tokio::runtime::Runtime::block_on
             at /Users/zacck/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.2.23/src/runtime/mod.rs:441:9
  23: oapth::integration_tests::integration_tests
             at ./src/integration_tests.rs:225:5
  24: oapth::integration_tests::integration_tests::{{closure}}
             at ./src/integration_tests.rs:225:5
  25: core::ops::function::FnOnce::call_once
             at /rustc/b1496c6e606dd908dd651ac2cce89815e10d7fc5/library/core/src/ops/function.rs:227:5
  26: core::ops::function::FnOnce::call_once
             at /rustc/b1496c6e606dd908dd651ac2cce89815e10d7fc5/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.


failures:
    integration_tests::integration_tests

test result: FAILED. 4 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out
```
